### PR TITLE
Allow importing a participatory text by pasting

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_from_editor_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_from_editor_participatory_text.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A command with all the business logic when an admin imports proposals from
+      # a participatory text rich text editor.
+      class ImportFromEditorParticipatoryText < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # form - A form object with the params.
+        def initialize(form)
+          @form = form
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) unless @form.valid?
+
+          transaction do
+            save_participatory_text_meta(@form)
+            parse_participatory_text_content(@form)
+          end
+
+          broadcast(:ok)
+        # rescue StandardError
+        #   broadcast(:invalid_file)
+        end
+
+        private
+
+        # Persist ParticipatoryText related meta information.
+        def save_participatory_text_meta(form)
+          document = ParticipatoryText.find_or_initialize_by(component: form.current_component)
+          document.update!(title: form.title, description: form.description)
+        end
+
+        def parse_participatory_text_content(form)
+          return if form.content.blank?
+
+          markdown = Decidim::Proposals::HtmlToMarkdown.new(form.content).to_md
+          parser = MarkdownToProposals.new(form.current_component, form.current_user)
+          parser.parse(markdown)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/import_editor_participatory_text_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/import_editor_participatory_text_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A form object to be used when admin users want to import a collection of proposals
+      # from a participatory text written in a rich text editor.
+      class ImportEditorParticipatoryTextForm < Decidim::Form
+        include TranslatableAttributes
+
+        # WARNING: consider adding/removing the relative translation key at
+        # decidim.assemblies.admin.new_import.accepted_types when modifying this hash
+        ACCEPTED_MIME_TYPES = Decidim::Proposals::DocToMarkdown::ACCEPTED_MIME_TYPES
+
+        translatable_attribute :title, String
+        translatable_attribute :description, String
+        attribute :content
+
+        validates :title, translatable_presence: true
+        validates :content, presence: true, if: :new_participatory_text?
+
+        # Assume it's a NEW participatory_text if there are no proposals
+        # Validate content presence while CREATING proposals from content
+        # Allow skipping content validation while UPDATING title/description
+        def new_participatory_text?
+          Decidim::Proposals::Proposal.where(component: current_component).blank?
+        end
+
+        def default_locale
+          current_participatory_space.organization.default_locale
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/_bulk-actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/_bulk-actions.html.erb
@@ -1,2 +1,3 @@
 <%= link_to t(".discard_all"), discard_participatory_texts_path, method: "POST", id: "discard-all", class: "button tiny button--title alert", data: { confirm: t(".are_you_sure") } %>
 <%= link_to t(".import_doc"), new_import_participatory_texts_path, id: "import-doc", class: "button tiny button--title" %>
+<%= link_to t(".write_document"), new_editor_participatory_texts_path, id: "write-doc", class: "button tiny button--title" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/new_editor.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/new_editor.html.erb
@@ -1,0 +1,39 @@
+<%= decidim_form_for(@import, url: import_from_editor_participatory_texts_path, class: "form grid-container") do |form| %>
+  <div class="card">
+    <div class="card-divider">
+      <h2 class="card-title"><%= t(".title") %></h2>
+    </div>
+    <div class="card-section">
+      <div class="grid-x">
+        <div class="cell">
+          <div id="import-title" class="row column">
+            <%= form.translated :text_field, :title, autofocus: true %>
+          </div>
+        </div>
+      </div>
+      <div class="grid-x">
+        <div class="cell">
+          <div id="import-desc" class="row column">
+            <%= form.translated :text_area, :description %>
+          </div>
+        </div>
+      </div>
+      <div class="grid-x">
+        <div class="cell">
+          <fieldset>
+            <legend> <%= t(".editor_description") %> </legend>
+              <div class="row column">
+                <%= editor_field_tag "content", "", toolbar: "full" %>
+              </div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="grid-x align-center mt-sm">
+    <%= form.submit t(".import") %>
+  </div>
+  <div class="grid-x align-center">
+    <%= t(".bottom_hint") %>
+  </div>
+<% end -%>

--- a/decidim-proposals/config/locales/de.yml
+++ b/decidim-proposals/config/locales/de.yml
@@ -373,6 +373,7 @@ de:
             are_you_sure: Sind Sie sicher, den gesamten Entwurf des partizipativen Textes zu verwerfen?
             discard_all: Alle verwerfen
             import_doc: Dokument importieren
+            write_document: Dokument schreiben
           discard:
             success: Alle Mitentscheidungsentwürfe wurden verworfen.
           import:
@@ -384,6 +385,11 @@ de:
             publish_document: Dokument veröffentlichen
             save_draft: Entwurf speichern
             title: VORSCHAU TEILNEHMERTEXT
+          new_editor:
+            title: Dokument hinzufügen
+            bottom_hint: "(Sie können Dokumentabschnitte in der Vorschau anzeigen und sortieren.)"
+            editor_description: "Schreiben Sie ein Dokument oder fügen Sie es ein und verwenden Sie Überschriften, um die Absätze zu trennen."
+            import: Import
           new_import:
             accepted_mime_types:
               md: Markdown

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -406,6 +406,7 @@ en:
             are_you_sure: Are you sure to discard the whole participatory text draft?
             discard_all: Discard all
             import_doc: Import document
+            write_document: Write document
           discard:
             success: All participatory text drafts have been discarded.
           import:
@@ -417,6 +418,11 @@ en:
             publish_document: Publish document
             save_draft: Save draft
             title: Preview participatory text
+          new_editor:
+            title: Add document
+            bottom_hint: "(You will be able to preview and sort document sections)"
+            editor_description: "Write or paste your document and use heading style to seperate paragraphs"
+            import: Import
           new_import:
             accepted_mime_types:
               md: Markdown

--- a/decidim-proposals/lib/decidim/proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals.rb
@@ -17,7 +17,8 @@ module Decidim
     autoload :MarkdownToProposals, "decidim/proposals/markdown_to_proposals"
     autoload :ParticipatoryTextSection, "decidim/proposals/participatory_text_section"
     autoload :DocToMarkdown, "decidim/proposals/doc_to_markdown"
-    autoload :OdtToMarkdown, "decidim/proposals/odt_to_markdown"
+    autoload :OdtToMarkdown, "decidim/proposals/html_to_markdown"
+    autoload :HtmlToMarkdown, "decidim/proposals/odt_to_markdown"
     autoload :Valuatable, "decidim/proposals/valuatable"
 
     include ActiveSupport::Configurable

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -27,9 +27,12 @@ module Decidim
 
         resources :participatory_texts, only: [:index] do
           collection do
+            get :new_editor
             get :new_import
             post :import
             patch :import
+            post :import_from_editor
+            patch :import_from_editor
             post :update
             post :discard
           end

--- a/decidim-proposals/lib/decidim/proposals/html_to_markdown.rb
+++ b/decidim-proposals/lib/decidim/proposals/html_to_markdown.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "kramdown"
+
+module Decidim
+  module Proposals
+    # This class parses a participatory text document from quill editor in markdown
+    #
+    # This implementation uses Kramdown Base renderer.
+    #
+    class HtmlToMarkdown
+      # Public: Initializes the serializer with a proposal.
+      def initialize(html)
+        @html = html
+      end
+
+      def to_md
+        ::Kramdown::Document.new(@html, input: 'html').to_kramdown
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new page with a quill editor to allow
importing a participatory text by pasting it in
a text area and formatting it
